### PR TITLE
Inject parameters into mocked factories

### DIFF
--- a/Tests/MDITests/MDITests.swift
+++ b/Tests/MDITests/MDITests.swift
@@ -63,11 +63,11 @@ extension MDITests {
 
                     #if DEBUG
                     fileprivate enum TestProtocol_MockHolder {
-                        static var mock: (() -> (any TestProtocol))? = nil
+                        static var mock: ((Int) -> (any TestProtocol))? = nil
                     }
                     #endif
 
-                    static func mock(_: (any TestProtocol).Type, factory: (() -> (any TestProtocol))?) {
+                    static func mock(_: (any TestProtocol).Type, factory: ((Int) -> (any TestProtocol))?) {
                         #if DEBUG
                         TestProtocol_MockHolder.mock = factory
                         #endif
@@ -76,14 +76,14 @@ extension MDITests {
                     static func resolve(_: (any TestProtocol).Type, _ arg0: Int) -> (any TestProtocol) {
                         #if DEBUG
                         if let mock = TestProtocol_MockHolder.mock {
-                            return mock()
+                            return mock(arg0)
                         }
                         #endif
                         return (Test.init(int:))(arg0)
                     }
 
                     static func resolve(_ arg0: Int) -> (any TestProtocol) {
-                        return (Test.init(int:))(arg0)
+                        return resolve((any TestProtocol).self, arg0)
                     }
                 }
                 """,


### PR DESCRIPTION
## WHAT WAS DONE:

Changed the mocking code generated by `DIFactoryRegistration` to pass parameters into the mocking factory.

## WHY:

The previous implementation of `DIFactoryRegistration` generated mocking code that expected a no-parameters factory for the mocked type.
This discarded incoming parameters which would cause difficulty for testing in certain scenarios.

## HOW:
- Refactor `SyntaxUtils.generateMockFunction` and `generateMockFunctionCall` to account for function parameters
- Refactor `DIFactoryRegistration` to pass `resolve` parameters to mocking functionality
- Update unit tests

## BREAKING?
**YES**
Client code consuming the `mock(...)` function of factories will break, as the mocking function should now receive the same parameters as the `resolve` function for the same type.