### PR TITLE
Add plain types factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Presently, the following limitations exist (due to compiler bug):
 - The hub type used to register dependencies must either be a `class` or a `struct`; using `enum`s will result in the compiler failing
 - All dependencies must be registered in the same file where the hub type is declared (they can be split into multiple `extension`s for organization though)
 
+# Versions
+
+## Version 4.1.0
+
+- Restores factory for "naked" types, treating all stated dependencies as explicit.
+
 ## Version 4.0.0
 
 - Fully deprecates `@FactoryRegister(_:parameterTypes:factory:)` in favour of `@FactoryRegister(_:parameterTypes:using:)` (which allows mixing explict parameters with auto-resolved dependencies)

--- a/Sources/MDI/MDI.swift
+++ b/Sources/MDI/MDI.swift
@@ -36,7 +36,7 @@ public macro SingletonRegister<each Parameter, ResolvedType>(
  Non-resolvable dependencies (marked `.explicit(Dependency.self)`) are exposed, while resolvable dependencies (marked `.resolved(Dependency.self)`) are implicitly resolved
  Example:
 
- ```swift
+ ```
  protocol AppState {}
  protocol UserSession {}
 
@@ -53,26 +53,25 @@ public macro SingletonRegister<each Parameter, ResolvedType>(
     }
  }
 
- @AutoRegister((any AppState).self, factory: AppStateImpl.init)
- @FactoryRegister((any UserSession).self, parameterTypes: .resolved((any AppState).self), .explicit(String.self), with: UserSessionImpl.init)
+ @FactoryRegister((any UserSession).self, parameterTypes: .resolved((any AppState).self), .explicit(String.self), with: UserSessionImpl.init(appState:sessionId:))
  class Dependency { }
  ```
 
  Will expose the following resolution method, exposing the non-resolvable parameter only, while auto resolving the resolvable dependency:
 
- ```swift
+ ```
  ...
  class Dependency {
-    static func resolve(_: (any UserSession).Type, _ arg0: String) -> any UserSession {
-        return (UserSessionImpl.init)(Self.resolve(), arg0)
+    static func resolve(_: (any UserSession).Type, sessionId: String) -> any UserSession {
+        return (UserSessionImpl.init(appState:sessionId:))(Self.resolve(), sessionId)
     }
  }
  ```
 
  - parameters:
- - type: The type being registered into the assembly; typically a `protocol`. Will be the return type when calling `resolve`
- - parameterTypes: The types of each input necessary to execute the `factory`
- - factory: The factory to be used to resolve the dependency
+    - type: The type being registered into the assembly; typically a `protocol`. Will be the return type when calling `resolve`
+    - parameterTypes: The types of each input necessary to execute the `factory`
+    - factory: The factory to be used to resolve the dependency
 
  - note: `factory` might be a `init` for the concrete type, or a wrapper method, e.g. resolving all type dependencies via `resolve()` while exposing only non-resolvable parameters
  */
@@ -81,6 +80,42 @@ public macro FactoryRegister<each Parameter, ResolvedType>(
     _ type: ResolvedType.Type,
     parameterTypes: repeat MDIFactoryDependency<each Parameter>,
     using factory: (repeat each Parameter) -> ResolvedType
+) = #externalMacro(module: "MDIMacros", type: "DIFactoryAutoRegistration")
+
+/**
+ Registers a dependency into the assembly
+
+ All specified types are treated as dependencies that must be injected into the factory expression.
+ For the previous example, using plain types:
+
+ ```
+ @FactoryRegister((any UserSession).self, parameterTypes: (any AppState).self, String.self, factory: UserSessionImpl.init(appState:sessionId:))
+ class Dependency { }
+
+ ```
+
+ Will expose the following resolution method, exposing all parameters:
+
+ ```
+ class Dependency {
+    static func resolve(_: (any UserSession).Type, appState: any AppState, sessionId: String) -> any UserSession {
+        return (UserSessionImpl.init(appState:sessionId:))(appState, sessionId)
+    }
+ }
+ ```
+
+ - parameters:
+    - type: The type being registered into the assembly; typically a `protocol`. Will be the return type when calling `resolve`
+    - parameterTypes: The types of each input necessary to execute the `factory`
+    - factory: The factory to be used to resolve the dependency
+
+ - note: `factory` might be a `init` for the concrete type, or a wrapper method, e.g. resolving all type dependencies via `resolve()` while exposing only non-resolvable parameters
+ */
+@attached(member, names: arbitrary)
+public macro FactoryRegister<each Parameter, ResolvedType>(
+    _ type: ResolvedType.Type,
+    parameterTypes: repeat (each Parameter).Type,
+    factory: (repeat each Parameter) -> ResolvedType
 ) = #externalMacro(module: "MDIMacros", type: "DIFactoryAutoRegistration")
 
 // MARK: - Opaque -
@@ -121,7 +156,7 @@ public macro OpaqueSingletonRegister<each Parameter, ResolvedType>(
  Non-resolvable dependencies (marked `.explicit(Dependency.self)`) are exposed, while resolvable dependencies (marked `.resolved(Dependency.self)`) are implicitly resolved
  Example:
 
- ```swift
+ ```
  protocol AppState {}
  protocol UserSession {}
 
@@ -166,4 +201,56 @@ public macro OpaqueFactoryRegister<each Parameter, ResolvedType>(
     _ type: ResolvedType.Type,
     parameterTypes: repeat MDIFactoryDependency<each Parameter>,
     using factory: (repeat each Parameter) -> ResolvedType
+) = #externalMacro(module: "MDIMacros", type: "DIOpaqueFactoryRegistration")
+
+/**
+ Registers a dependency into the assembly
+
+ All specified types are treated as dependencies that must be injected into the factory expression.
+ For the previous example, using plain types:
+
+ ```
+ protocol AppState {}
+ protocol UserSession {}
+
+ class AppStateImpl: AppState {
+    init() {
+    }
+ }
+ class UserSessionImpl: UserSession {
+    init(
+        appState: any AppState,
+        sessionId: String
+    ) {
+        ...
+    }
+ }
+
+ @FactoryRegister((any UserSession).self, parameterTypes: (any AppState).self, String.self, with: UserSessionImpl.init(appState:sessionId))
+ class Dependency { }
+ ```
+
+ Will expose the following resolution method, exposing all dependencies:
+
+ ```swift
+ ...
+ class Dependency {
+    static func resolve(_: (any UserSession).Type, appState: any AppState, sessionId: String) -> any UserSession {
+        return (UserSessionImpl.init(appState:sessionId:))(appState, sessionId)
+    }
+ }
+ ```
+
+ - parameters:
+ - type: The type being registered into the assembly; typically a `protocol`. Will be the return type when calling `resolve`
+ - parameterTypes: The types of each input necessary to execute the `factory`
+ - factory: The factory to be used to resolve the dependency
+
+ - note: `factory` might be a `init` for the concrete type, or a wrapper method, e.g. resolving all type dependencies via `resolve()` while exposing only non-resolvable parameters
+ */
+@attached(member, names: arbitrary)
+public macro OpaqueFactoryRegister<each Parameter, ResolvedType>(
+    _ type: ResolvedType.Type,
+    parameterTypes: repeat (each Parameter).Type,
+    factory: (repeat each Parameter) -> ResolvedType
 ) = #externalMacro(module: "MDIMacros", type: "DIOpaqueFactoryRegistration")

--- a/Sources/MDIMacros/Macros/Existencial/DIFactoryAutoRegistration.swift
+++ b/Sources/MDIMacros/Macros/Existencial/DIFactoryAutoRegistration.swift
@@ -49,12 +49,6 @@ extension DIFactoryAutoRegistration: MemberMacro {
         let factoryNamedParameters = SyntaxUtils.getFactoryNamedParameters(from: factory)
         let factoryTypesFull = SyntaxUtils.getFactoryRegistrableParameterTypes(from: node)
         let factoryTypes = factoryTypesFull.compactMap { $0.resolve ? nil : $0.type }
-//        let factoryParameters = factoryTypes
-//            .enumerated()
-//            .map { index, type in
-//                "_ arg\(index): \(type)"
-//            }
-//            .joined(separator: ", ")
         var argIndex = 0
         var factoryParameters: [String] = []
         var factoryParameterNames: [String] = []

--- a/Sources/MDIMacros/Utils/SyntaxUtils.swift
+++ b/Sources/MDIMacros/Utils/SyntaxUtils.swift
@@ -144,26 +144,30 @@ enum SyntaxUtils {
         return types
             .inRange(1 ..< types.count - 1)
             .compactMap { type -> (Bool, SyntaxProtocol)? in
-                guard
+                if
                     let enumerationItem = type.as(LabeledExprSyntax.self)?.expression.as(FunctionCallExprSyntax.self),
                     let caseName = enumerationItem.calledExpression.as(MemberAccessExprSyntax.self)?.declName.baseName.text,
                     enumerationItem.arguments.count == 1,
                     let dependency = enumerationItem.arguments.first?.expression.as(MemberAccessExprSyntax.self)?.base
-                else {
-                    return nil
-                }
+                {
+                    let resolve: Bool
 
-                let resolve: Bool
+                    if caseName == "resolved" {
+                        resolve = true
+                    } else if caseName == "explicit" {
+                        resolve = false
+                    } else {
+                        return nil
+                    }
 
-                if caseName == "resolved" {
-                    resolve = true
-                } else if caseName == "explicit" {
-                    resolve = false
+                    return (resolve, dependency)
+                } else if
+                    let dependency = type.as(LabeledExprSyntax.self)?.expression.as(MemberAccessExprSyntax.self)?.base
+                {
+                    return (false, dependency)
                 } else {
                     return nil
                 }
-
-                return (resolve, dependency)
             }
     }
 

--- a/Tests/MDITests/MDIOpaqueTests.swift
+++ b/Tests/MDITests/MDIOpaqueTests.swift
@@ -23,11 +23,6 @@ extension MDIOpaqueTests {
 #if canImport(MDIMacros)
         assertMacroExpansion(
                 """
-                protocol TestProtocol {}
-                struct Test: TestProtocol {
-                    init(theme: any Theme, int: Int) { }
-                }
-
                 @OpaqueFactoryRegister((any TestProtocol).self, parameterTypes: .resolved((any Theme).self), .explicit(Int.self), using: Test.init(theme:int:))
                 extension Dependency {
                 }
@@ -35,10 +30,6 @@ extension MDIOpaqueTests {
                 expandedSource:
                 """
 
-                protocol TestProtocol {}
-                struct Test: TestProtocol {
-                    init(theme: any Theme, int: Int) { }
-                }
                 extension Dependency {
 
                     static func resolve(_: (any TestProtocol).Type, int: Int) -> some TestProtocol {
@@ -53,15 +44,35 @@ extension MDIOpaqueTests {
 #endif
     }
 
+    func testFactoryAutoRegisterWithFullExplicitTypes() throws {
+#if canImport(MDIMacros)
+        assertMacroExpansion(
+                """
+                @OpaqueFactoryRegister((any AppState).self, parameterTypes: Date.self, String.self, factory: AppStateImpl.factory(boot:version:))
+                extension Dependency {
+                }
+                """,
+                expandedSource:
+                """
+
+                extension Dependency {
+
+                    static func resolve(_: (any AppState).Type, boot: Date, version: String) -> some AppState {
+                        return (AppStateImpl.factory(boot:version:))(boot, version)
+                    }
+                }
+                """,
+                macros: opaqueTestMacros
+        )
+#else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+#endif
+    }
+
     func testSingletonRegister() throws {
 #if canImport(MDIMacros)
         assertMacroExpansion(
                 """
-                protocol TestProtocol {}
-                struct Test: TestProtocol {
-                    init() { }
-                }
-
                 @OpaqueSingletonRegister((any TestProtocol).self, factory: Test.init)
                 extension Dependency {
                 }
@@ -69,10 +80,6 @@ extension MDIOpaqueTests {
                 expandedSource:
                 """
 
-                protocol TestProtocol {}
-                struct Test: TestProtocol {
-                    init() { }
-                }
                 extension Dependency {
 
                     fileprivate enum TestProtocol_Holder {
@@ -96,11 +103,6 @@ extension MDIOpaqueTests {
 #if canImport(MDIMacros)
         assertMacroExpansion(
                 """
-                protocol TestProtocol {}
-                struct Test: TestProtocol {
-                    init(nested: any Nested) { }
-                }
-
                 @OpaqueAutoRegister((any TestProtocol).self, parameterTypes: (any Nested).self, factory: Test.init(nested:))
                 extension Dependency {
                 }
@@ -108,10 +110,6 @@ extension MDIOpaqueTests {
                 expandedSource:
                 """
 
-                protocol TestProtocol {}
-                struct Test: TestProtocol {
-                    init(nested: any Nested) { }
-                }
                 extension Dependency {
 
                     static func resolve(_: (any TestProtocol).Type) -> some TestProtocol {


### PR DESCRIPTION
- Add @FactoryRegister(_:parameterTypes:factory:) using plain types where all parameters are exposed
- Add @OpaqueFactoryRegister(_:parameterTypes:factory:) using plain types where all parameters are exposed
- Unit tests
- README